### PR TITLE
Add cron job to manage Prowlarr custom indexers

### DIFF
--- a/prowlarr/cronjob-rbac.yaml
+++ b/prowlarr/cronjob-rbac.yaml
@@ -1,0 +1,32 @@
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prowlarr-custom-indexers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prowlarr-custom-indexers
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    resourceNames:
+      - prowlarr
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prowlarr-custom-indexers
+subjects:
+  - kind: ServiceAccount
+    name: prowlarr-custom-indexers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prowlarr-custom-indexers

--- a/prowlarr/cronjob.yaml
+++ b/prowlarr/cronjob.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: prowlarr-custom-indexers
+spec:
+  schedule: "0 */12 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: prowlarr-custom-indexers
+        spec:
+          serviceAccountName: prowlarr-custom-indexers
+          restartPolicy: OnFailure
+          containers:
+            - name: update-custom-indexers
+              image: curlimages/curl:8.8.0
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+
+                  CUSTOM_DIR="/config/Definitions/Custom"
+                  mkdir -p "${CUSTOM_DIR}"
+
+                  download() {
+                    url="$1"
+                    filename="$2"
+                    tmp_file="$(mktemp)"
+                    curl -fsSLo "${tmp_file}" "${url}"
+                    rm -f "${CUSTOM_DIR}/${filename}"
+                    mv "${tmp_file}" "${CUSTOM_DIR}/${filename}"
+                  }
+
+                  download "https://raw.githubusercontent.com/Jackett/Jackett/master/src/Jackett.Common/Definitions/yggtorrent.yml" "yggtorrent.yml"
+                  download "https://raw.githubusercontent.com/Jackett/Jackett/master/src/Jackett.Common/Definitions/yggcookie.yml" "yggcookie.yml"
+                  download "https://gist.githubusercontent.com/Clemv95/8bfded23ef23ec78f6678896f42a2b60/raw/4daa8700ee11950b7eb6a13e0b86341c1f584f1a/ygg-api-download.yml" "ygg-api-download.yml"
+
+                  TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  NAMESPACE="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+                  API_SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+                  TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                  PATCH_BODY=$(printf '{"spec":{"template":{"metadata":{"annotations":{"custom-indexers/last-sync":"%s"}}}}}' "${TIMESTAMP}")
+
+                  curl -fsS \
+                    --header "Authorization: Bearer ${TOKEN}" \
+                    --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                    -XPATCH \
+                    -H "Content-Type: application/strategic-merge-patch+json" \
+                    -d "${PATCH_BODY}" \
+                    "${API_SERVER}/apis/apps/v1/namespaces/${NAMESPACE}/deployments/prowlarr"
+              volumeMounts:
+                - name: prowlarr-config
+                  mountPath: /config
+          volumes:
+            - name: prowlarr-config
+              persistentVolumeClaim:
+                claimName: prowlarr-config

--- a/prowlarr/kustomization.yaml
+++ b/prowlarr/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: prowlarr
 resources:
+  - namespace.yaml
   - config-pv.yaml
   - config-pvc.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml
-  - namespace.yaml
+  - cronjob-rbac.yaml
+  - cronjob.yaml


### PR DESCRIPTION
## Summary
- add a scheduled CronJob that refreshes custom Jackett indexer definitions in the Prowlarr config volume every 12 hours
- grant the job a service account with RBAC to patch the deployment so it restarts after updates
- include the new CronJob and RBAC resources in the Prowlarr Kustomize configuration

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_68cf0fe617d08327834368957f9f0b56