### PR TITLE
Add Last.fm environment variables to Navidrome deployment

### DIFF
--- a/navidrome/deployment.yaml
+++ b/navidrome/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
         - name: navidrome
           image: deluan/navidrome:latest
+          env:
+            - name: ND_LASTFM_APIKEY
+              value: "af0e77858a2da6dece27f69af333c622"
+            - name: ND_LASTFM_SECRET
+              value: "878e939c8ff4eb3f129ed97f9639cc49"
           ports:
             - containerPort: 4533
               protocol: TCP


### PR DESCRIPTION
### Motivation
- Provide Last.fm credentials to Navidrome to enable scrobbling and Last.fm integration by injecting `ND_LASTFM_APIKEY` and `ND_LASTFM_SECRET` into the container environment.

### Description
- Added an `env` block to `navidrome/deployment.yaml` with `ND_LASTFM_APIKEY` and `ND_LASTFM_SECRET` environment variables for the Navidrome container.

### Testing
- No automated tests were run because this is a configuration-only change; the change was committed and a PR description was prepared successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989188ee7788327ab7de1bdb2ebd501)